### PR TITLE
bug fixes and support for single proxy without removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@ pystemon
 ========
 Monitoring tool for PasteBin-alike sites written in Python
 
+Features added and bugs fixed in this fork:
+------------------------------------------
+* update-min and update-max are now honoured
+* added option to enable or disable proxy use
+* added option to enable single or random proxy (random proxies are still removed after a few errors)
+* disabled redis by default
+* redis dependency only loaded if redis is enabled
+
+My original fork can be found here https://github.com/cvandeplas/pystemon/pull/26. Meanwhile others have contributed to this repo :)
+
+
+Original README below:
+----------------------
+
 Copyleft AGPLv3 - Christophe Vandeplas - christophe@vandeplas.com  
 Feel free to use the code, but please share the changes you've made
 

--- a/pystemon.py
+++ b/pystemon.py
@@ -599,13 +599,16 @@ def downloadUrl(url, data=None, cookie=None):
             response = opener.open(url)
         htmlPage = unicode(response.read(), errors='replace')
         # If we receive a "slow down" message, follow Pastebin recommendation!
-        if 'Please slow down' in htmlPage:
-            logger.warning("Slow down message received for {url}. Waiting 5 seconds".format(url))
-            time.sleep(5)
-            return downloadUrl(url)
+        
         return htmlPage, response.headers
-    except urllib2.HTTPError:
-        logger.warning("ERROR: HTTP Error ############################# " + url)
+    except urllib2.HTTPError, e:
+        if 403 == e.code:
+            htmlPage = e.read()
+            if 'Please slow down' in htmlPage or 'has temporarily blocked your computer' in htmlPage:
+                logger.warning("Slow down message received for {url}. Waiting 5 seconds".format(url=url))
+                time.sleep(5)
+                return downloadUrl(url)
+        logger.warning("ERROR: HTTP Error ##### {e} ######################## {url}".format(e=e, url=url))
         return None, None
     except urllib2.URLError:
         logger.debug("ERROR: URL Error ############################# " + url)

--- a/pystemon.py
+++ b/pystemon.py
@@ -535,7 +535,7 @@ def loadUserAgentsFromFile(filename):
 
 
 def getRandomUserAgent():
-    global proxies_list
+    global user_agents_list
     if user_agents_list:
         return random.choice(user_agents_list)
     return None
@@ -829,11 +829,11 @@ def parseConfigFile(configfile):
             exit(1)
     # TODO verify validity of config parameters
     if yamlconfig['proxy']['random']:
-        loadProxiesFromFile(yamlconfig['proxy']['file'])
-    if yamlconfig['user-agent']['random']:
         # TODO validity check only, proxy file will be loaded from file listener
         pass
-        # loadUserAgentsFromFile(yamlconfig['user-agent']['file'])
+        # loadProxiesFromFile(yamlconfig['proxy']['file'])
+    if yamlconfig['user-agent']['random']:
+        loadUserAgentsFromFile(yamlconfig['user-agent']['file'])
 
 
 if __name__ == "__main__":

--- a/pystemon.py
+++ b/pystemon.py
@@ -566,8 +566,12 @@ def failedProxy(proxy):
     if proxies_failed.count(proxy) >= 2 and proxies_list.count(proxy) >= 1:
         logger.info("Removing proxy {0} from proxy list because of to many errors errors.".format(proxy))
         proxies_lock.acquire()
-        proxies_list.remove(proxy)
+        try:
+            proxies_list.remove(proxy)
+        except ValueError:
+            pass
         proxies_lock.release()
+        logger.info("Proxies left: {0}".format(len(proxies_list)))
 
 
 class NoRedirectHandler(urllib2.HTTPRedirectHandler):

--- a/pystemon.py
+++ b/pystemon.py
@@ -413,7 +413,7 @@ class PastieSniptNet(Pastie):
             htmlDom = BeautifulSoup(downloaded_page)
             # search for <textarea class="raw">
             textarea = htmlDom.first('textarea', {'class': 'raw'})
-            if textarea:
+            if textarea and textarea.contents:
                 # replace html entities like &gt;
                 decoded = BeautifulSoup(textarea.contents[0], convertEntities=BeautifulSoup.HTML_ENTITIES)
                 self.pastie_content = decoded.contents[0]

--- a/pystemon.py
+++ b/pystemon.py
@@ -605,8 +605,8 @@ def downloadUrl(url, data=None, cookie=None):
         if 403 == e.code:
             htmlPage = e.read()
             if 'Please slow down' in htmlPage or 'has temporarily blocked your computer' in htmlPage:
-                logger.warning("Slow down message received for {url}. Waiting 5 seconds".format(url=url))
-                time.sleep(5)
+                logger.warning("Slow down message received for {url}. Waiting 1 minute".format(url=url))
+                time.sleep(60)
                 return downloadUrl(url)
         logger.warning("ERROR: HTTP Error ##### {e} ######################## {url}".format(e=e, url=url))
         return None, None

--- a/pystemon.py
+++ b/pystemon.py
@@ -412,7 +412,7 @@ class PastieSniptNet(Pastie):
         if downloaded_page:
             htmlDom = BeautifulSoup(downloaded_page)
             # search for <textarea class="raw">
-            textarea = htmlDom.first('textarea', {'class': 'raw'})
+            textarea = htmlDom.find('textarea', {'class': 'raw'})
             if textarea and textarea.contents:
                 # replace html entities like &gt;
                 decoded = BeautifulSoup(textarea.contents[0], convertEntities=BeautifulSoup.HTML_ENTITIES)

--- a/pystemon.py
+++ b/pystemon.py
@@ -102,13 +102,16 @@ class PastieSite(threading.Thread):
             try:
                 sleep_time = random.randint(self.update_min, self.update_max)
                 # grabs site from queue
-                logger.info("Downloading pasties from {name}. Next download scheduled in {time} seconds".format(name=self.name, time=sleep_time))
+                logger.info("Checking for new pasties from {name}. Next download scheduled in {time} seconds".format(name=self.name, time=sleep_time))
                 # get the list of last pasties, but reverse it so we first have the old
                 # entries and then the new ones
                 last_pasties = self.getLastPasties()
                 if last_pasties:
                     for pastie in reversed(last_pasties):
                         queues[self.name].put(pastie)  # add pastie to queue
+                    logger.info("Found {amount} new pasties for site {site}. There are now {qsize} pasties to be downloaded.".format(amount=len(last_pasties),
+                                                                                                          site=self.name,
+                                                                                                          qsize=queues[self.name].qsize()))
             # catch unknown errors
             except Exception, e:
                 logger.error("Thread for {name} crashed unexpectectly, recovering...: {e}".format(name=self.name, e=e))
@@ -137,7 +140,6 @@ class PastieSite(threading.Thread):
                 else:
                     pastie = Pastie(self, pastie_id)
                 pasties.append(pastie)
-            logger.info("Found {amount} new pasties for site {site}".format(amount=len(pasties), site=self.name))
             return pasties
         logger.error("No last pasties matches for regular expression site:{site} regex:{regex}. Error in your regex? Dumping htmlPage \n {html}".format(site=self.name, regex=self.archive_regex, html=htmlPage.encode('utf8')))
         return False

--- a/pystemon.py
+++ b/pystemon.py
@@ -337,7 +337,7 @@ Below (after newline) is the content of the pastie:
 
 {content}
 
-        '''.format(site=self.site.name, url=self.url, matches=self.matchesToRegex(), content=self.pastie_content)
+        '''.format(site=self.site.name, url=self.url, matches=self.matchesToRegex(), content=self.pastie_content.encode('utf8'))
         msg.attach(MIMEText(message))
         # send out the mail
         try:

--- a/pystemon.py
+++ b/pystemon.py
@@ -83,7 +83,7 @@ class PastieSite(threading.Thread):
             true_socket = socket.socket
             socket.socket = make_bound_socket(self.ip_addr)
         except:
-            print "Using default IP address"
+            logger.debug("Using default IP address")
 
         self.save_dir = yamlconfig['archive']['dir'] + os.sep + name
         self.archive_dir = yamlconfig['archive']['dir-all'] + os.sep + name
@@ -115,7 +115,7 @@ class PastieSite(threading.Thread):
             # catch unknown errors
             except Exception, e:
                 logger.error("Thread for {name} crashed unexpectectly, recovering...: {e}".format(name=self.name, e=e))
-                logger.debug(traceback.format_exc())
+                logger.error(traceback.format_exc())
             time.sleep(sleep_time)
 
     def getLastPasties(self):
@@ -439,7 +439,8 @@ class ThreadPasties(threading.Thread):
             # catch unknown errors
             except Exception, e:
                 logger.error("ThreadPasties for {name} crashed unexpectectly, recovering...: {e}".format(name=self.name, e=e))
-                logger.debug(traceback.format_exc())
+                logger.error("    pastie from {0} with id {1}".format(self.name, pastie.id))
+                logger.error(traceback.format_exc())
 
 
 def main():

--- a/pystemon.yaml
+++ b/pystemon.yaml
@@ -69,8 +69,8 @@ site:
     archive-url: 'http://pastebin.com/archive'
     archive-regex: '<a href="/(\w{8})">.+</a></td>'
     download-url: 'http://pastebin.com/raw.php?i={id}'
-    update-max: 40
-    update-min: 30
+    update-max: 50
+    update-min: 40
  
   pastie.org:
     archive-url: 'http://pastie.org/pastes'

--- a/pystemon.yaml
+++ b/pystemon.yaml
@@ -3,7 +3,7 @@
 
 archive:
   save: yes             # Keep 
-  save-all: yes          # Keep a copy of all pasties
+  save-all: no          # Keep a copy of all pasties
   dir: "alerts"         # Directory where matching pasties should be kept
   dir-all: "archive"    # Directory where all pasties should be kept (if save-all is set to yes)
   compress: yes         # Store the pasties compressed
@@ -111,9 +111,7 @@ site:
 
   snipt.net:
     pastie-classname: PastieSniptNet
-    #archive-url: 'https://snipt.net/'
-    #archive-regex: '<h1><a href="/([a-zA-Z0-9-_/]+)/">'
-    archive-url: 'https://snipt.net/?rss'
+    archive-url: 'https://snipt.net/public/?rss'
     archive-regex: '<link>https://snipt.net/(.+)/</link>'
     download-url: 'https://snipt.net/{id}/'
 

--- a/pystemon.yaml
+++ b/pystemon.yaml
@@ -104,11 +104,12 @@ site:
     archive-regex: '<a href="http://codepad.org/([a-zA-Z0-9]+)">view'
     download-url: 'http://codepad.org/{id}/raw.txt'
     
-  cdv.lt:
-    pastie-classname: PastieCdvLt
-    archive-url: 'http://cdv.lt/snippets'
-    archive-regex: '<a href="/([a-zA-Z0-9]+)">[0-9]'
-    download-url: 'http://cdv.lt/api/snippet/{id}'
+# Site seems offline now
+#  cdv.lt:
+#    pastie-classname: PastieCdvLt
+#    archive-url: 'http://cdv.lt/snippets'
+#    archive-regex: '<a href="/([a-zA-Z0-9]+)">[0-9]'
+#    download-url: 'http://cdv.lt/api/snippet/{id}'
 
   snipt.net:
     pastie-classname: PastieSniptNet

--- a/pystemon.yaml
+++ b/pystemon.yaml
@@ -80,7 +80,7 @@ site:
  
   pastie.org:
     archive-url: 'http://pastie.org/pastes'
-    archive-regex: '<a href="http://pastie.org/pastes/(\d{7})">'
+    archive-regex: '<a href="http://pastie.org/pastes/(\d+)">'
     download-url: 'http://pastie.org/pastes/{id}/text'
 
 # Site seems offline now
@@ -89,22 +89,18 @@ site:
 #    archive-regex: '<a href="http://nopaste.me/paste/([a-zA-Z0-9]+)">'
 #    download-url: 'http://nopaste.me/download/{id}.txt'
 
-  slexy.org:
-    archive-url: 'http://slexy.org/recent' 
-    archive-regex: '<a href="/view/([a-zA-Z0-9]+)">View paste</a>'
-    download-url: 'http://slexy.org/raw/{id}'
+# off line
+# pastesite.com:
+#    pastie-classname: PastiePasteSiteCom
+#    archive-url: 'http://pastesite.com/recent' 
+#    archive-regex: '<a href="(\d+)" title="View this Paste'
+#    download-url: 'http://pastesite.com/plain/{id}.txt'
 
-  pastesite.com:
-    pastie-classname: PastiePasteSiteCom
-    archive-url: 'http://pastesite.com/recent' 
-    archive-regex: '<a href="(\d+)" title="View this Paste'
-    download-url: 'http://pastesite.com/plain/{id}.txt'
+  gist.github.com:
+    archive-url: 'https://gist.github.com/discover'
+    archive-regex: '<a href="/([a-zA-Z0-9]+/[a-z0-9]+)">'
+    download-url: https://gist.githubusercontent.com/{id}/raw/
 
-#  gist.github.com:
-#    archive-url: 'https://gist.github.com/gists'
-#    archive-regex: '<span><a href="/([0-9]+)">gist'
-#    download-url: 'https://raw.github.com/gist/{id}'
-    
   codepad.org:
     archive-url: 'http://codepad.org/recent'
     archive-regex: '<a href="http://codepad.org/([a-zA-Z0-9]+)">view'
@@ -122,13 +118,16 @@ site:
     archive-url: 'https://snipt.net/public/?rss'
     archive-regex: '<link>https://snipt.net/(.+)/</link>'
     download-url: 'https://snipt.net/{id}/'
+	
+  ideone.com:
+    archive-url: 'http://ideone.com/recent'
+    archive-regex: '<a href="/([a-zA-Z0-9]+)">#'
+    download-url: 'http://ideone.com/plain/{id}'
 
-#  safebin.net:  # FIXME not finished
-#    archive-url: 'http://safebin.net/?archive'
-#    archive-regex: '<a title="[a-zA-Z0-9 :,]+" href="/([0-9]+)">'
-#    download-url: 'http://safebin.net/{id}'
-#    update-max: 60
-#    update-min: 50
+  justpaste.it:
+    archive-url: 'https://justpaste.it/topall'
+    archive-regex: '<a href="https://justpaste.it/([a-zA-Z0-9]+)">'
+    download-url: 'https://justpaste.it/{id}'
 
 
 # TODO

--- a/pystemon.yaml
+++ b/pystemon.yaml
@@ -77,10 +77,11 @@ site:
     archive-regex: '<a href="http://pastie.org/pastes/(\d{7})">'
     download-url: 'http://pastie.org/pastes/{id}/text'
 
-  nopaste.me:
-    archive-url: 'http://nopaste.me/recent' 
-    archive-regex: '<a href="http://nopaste.me/paste/([a-zA-Z0-9]+)">'
-    download-url: 'http://nopaste.me/download/{id}.txt'
+# Site seems offline now
+#  nopaste.me:
+#    archive-url: 'http://nopaste.me/recent' 
+#    archive-regex: '<a href="http://nopaste.me/paste/([a-zA-Z0-9]+)">'
+#    download-url: 'http://nopaste.me/download/{id}.txt'
 
   slexy.org:
     archive-url: 'http://slexy.org/recent' 

--- a/pystemon.yaml
+++ b/pystemon.yaml
@@ -80,7 +80,7 @@ site:
  
   pastie.org:
     archive-url: 'http://pastie.org/pastes'
-    archive-regex: '<a href="http://pastie.org/pastes/(\d+)">'
+    archive-regex: '<a href="http://pastie.org/pastes/(\d{7})">'
     download-url: 'http://pastie.org/pastes/{id}/text'
 
 # Site seems offline now
@@ -89,18 +89,22 @@ site:
 #    archive-regex: '<a href="http://nopaste.me/paste/([a-zA-Z0-9]+)">'
 #    download-url: 'http://nopaste.me/download/{id}.txt'
 
-# off line
-# pastesite.com:
-#    pastie-classname: PastiePasteSiteCom
-#    archive-url: 'http://pastesite.com/recent' 
-#    archive-regex: '<a href="(\d+)" title="View this Paste'
-#    download-url: 'http://pastesite.com/plain/{id}.txt'
+  slexy.org:
+    archive-url: 'http://slexy.org/recent' 
+    archive-regex: '<a href="/view/([a-zA-Z0-9]+)">View paste</a>'
+    download-url: 'http://slexy.org/raw/{id}'
 
-  gist.github.com:
-    archive-url: 'https://gist.github.com/discover'
-    archive-regex: '<a href="/([a-zA-Z0-9]+/[a-z0-9]+)">'
-    download-url: https://gist.githubusercontent.com/{id}/raw/
+  pastesite.com:
+    pastie-classname: PastiePasteSiteCom
+    archive-url: 'http://pastesite.com/recent' 
+    archive-regex: '<a href="(\d+)" title="View this Paste'
+    download-url: 'http://pastesite.com/plain/{id}.txt'
 
+#  gist.github.com:
+#    archive-url: 'https://gist.github.com/gists'
+#    archive-regex: '<span><a href="/([0-9]+)">gist'
+#    download-url: 'https://raw.github.com/gist/{id}'
+    
   codepad.org:
     archive-url: 'http://codepad.org/recent'
     archive-regex: '<a href="http://codepad.org/([a-zA-Z0-9]+)">view'
@@ -118,16 +122,13 @@ site:
     archive-url: 'https://snipt.net/public/?rss'
     archive-regex: '<link>https://snipt.net/(.+)/</link>'
     download-url: 'https://snipt.net/{id}/'
-	
-  ideone.com:
-    archive-url: 'http://ideone.com/recent'
-    archive-regex: '<a href="/([a-zA-Z0-9]+)">#'
-    download-url: 'http://ideone.com/plain/{id}'
 
-  justpaste.it:
-    archive-url: 'https://justpaste.it/topall'
-    archive-regex: '<a href="https://justpaste.it/([a-zA-Z0-9]+)">'
-    download-url: 'https://justpaste.it/{id}'
+#  safebin.net:  # FIXME not finished
+#    archive-url: 'http://safebin.net/?archive'
+#    archive-regex: '<a title="[a-zA-Z0-9 :,]+" href="/([0-9]+)">'
+#    download-url: 'http://safebin.net/{id}'
+#    update-max: 60
+#    update-min: 50
 
 
 # TODO

--- a/pystemon.yaml
+++ b/pystemon.yaml
@@ -14,7 +14,7 @@ db:
     file: 'db.sqlite3'  # The filename of the database
 
 redis:
-  queue: yes
+  queue: no
   server: "localhost"
   port: 6379
   database: 10
@@ -149,8 +149,10 @@ site:
 # Currently only HTTP proxies are permitted
 #
 proxy:
+  use: no
   random: no
-  file: 'proxies.txt'
+  single-proxy: 'http://127.0.0.1:8080' 
+  random-proxy-file: 'proxies.txt'
 
 #####
 # Configuration section for User-Agents


### PR DESCRIPTION
Hi, 
I forked your code because I needed to add a single proxy that is not removed upon failure, so I can use pystemon with TOR (which uses a SOCKS proxy, so it needs to be combined with something like delegate that converts HTTP to SOCKS).

In addition I implemented some bug fixes (in **bold** the ones I consider more important):
- **update-min and update-max are now honoured**
- added option to enable or disable proxy use
- **added option to enable single or random proxy (random proxies are still removed after a few errors)**
- disabled redis by default
- redis dependency only loaded if redis is enabled

Since I forked from other fork, this pull also has the following bug fixes:
- **prevent dead lock when multiple threads want to remove the same proxy server**
- **fix encoding problem when sending alert by email**
- bugfix for empty textarea on snipt.net
- replaced deprecated method from BeautifulSoup
- added file listener for proxy list and made proxy list a unique set
- **bugfix in user agent management**
