### PR TITLE
Update pystemon.yaml

### DIFF
--- a/pystemon.yaml
+++ b/pystemon.yaml
@@ -96,16 +96,16 @@ site:
     update-max: 50
     update-min: 40
 
-  pastie.org:
-    archive-url: 'http://pastie.org/pastes'
-    archive-regex: '<a href="http://pastie.org/pastes/(\d+)">'
-    download-url: 'http://pastie.org/pastes/{id}/text'
-
 # Site seems offline now
-#  nopaste.me:
-#    archive-url: 'http://nopaste.me/recent'
-#    archive-regex: '<a href="http://nopaste.me/paste/([a-zA-Z0-9]+)">'
-#    download-url: 'http://nopaste.me/download/{id}.txt'
+#  pastie.org:
+#    archive-url: 'http://pastie.org/pastes'
+#    archive-regex: '<a href="http://pastie.org/pastes/(\d+)">'
+#    download-url: 'http://pastie.org/pastes/{id}/text'
+
+  nopaste.me:
+    archive-url: 'https://nopaste.me/lists'
+    archive-regex: '<a href="https:\/\/nopaste.me\/view/([a-zA-Z0-9]+)">'
+    download-url: 'https://nopaste.me/view/raw/{id}'
 
   slexy.org:
     archive-url: 'http://slexy.org/recent'
@@ -124,10 +124,11 @@ site:
     archive-regex: '<a href="/([A-Za-z0-9]+/[A-Za-z0-9]+)">'
     download-url: 'https://gist.githubusercontent.com/{id}/raw/'
 
-  quickleak.se:
-    archive-url: 'http://www.quickleak.se/last-pastes.html'
-    archive-regex: '<td><a href="([A-Za-z0-9]+)">'
-    download-url: 'http://www.quickleak.se/{id}'
+# Site seems offline now
+#  quickleak.se:
+#    archive-url: 'http://www.quickleak.se/last-pastes.html'
+#    archive-regex: '<td><a href="([A-Za-z0-9]+)">'
+#    download-url: 'http://www.quickleak.se/{id}'
 
   codepad.org:
     archive-url: 'http://codepad.org/recent'

--- a/pystemon.yaml
+++ b/pystemon.yaml
@@ -82,7 +82,7 @@ site:
 
   pastebin.com:
     archive-url: 'https://pastebin.com/archive'
-    archive-regex: '<a href="/(\w{8})">.+</a></td>'
+    archive-regex: '<a href="\/(\w{8})">'
     download-url: 'https://pastebin.com/raw/{id}'
     update-max: 50
     update-min: 40

--- a/pystemon.yaml
+++ b/pystemon.yaml
@@ -81,9 +81,9 @@ site:
 #                       # This is practical for sites that require custom fetchPastie() functions
 
   pastebin.com:
-    archive-url: 'http://pastebin.com/archive'
+    archive-url: 'https://pastebin.com/archive'
     archive-regex: '<a href="/(\w{8})">.+</a></td>'
-    download-url: 'http://pastebin.com/raw/{id}'
+    download-url: 'https://pastebin.com/raw/{id}'
     update-max: 50
     update-min: 40
 


### PR DESCRIPTION
pastebin.com now uses https. Searching fails over plain http.