### PR TITLE
PID file path and name configuration

### DIFF
--- a/pystemon.yaml
+++ b/pystemon.yaml
@@ -1,6 +1,9 @@
 #network:   # Network settings
 #  ip: '1.1.1.1'  # Specify source IP address if you want to bind on a specific one
 
+pid:
+  filename: '/var/run/pystemon.pid'
+
 archive:
   save: yes             # Keep
   save-all: yes          # Keep a copy of all pasties


### PR DESCRIPTION
Allow to configure the path and name of the PID file.
Please see changes to 'pystemon.py' as well.