### PR TITLE
PID file name and path configuration

### DIFF
--- a/pystemon.py
+++ b/pystemon.py
@@ -899,7 +899,7 @@ def main_as_daemon():
         pid = os.fork()
 
         if pid > 0:
-            pid_file = open('pid', 'w')
+            pid_file = open(yamlconfig['pid']['filename'], 'w')
             pid_file.write(str(pid))
             pid_file.close()
             print 'pystemon started as daemon'
@@ -966,11 +966,11 @@ if __name__ == "__main__":
     parse_config_file(options.config)
     # run the software
     if options.kill:
-        if os.path.isfile('pid'):
-            f = open('pid', 'r')
+        if os.path.isfile(yamlconfig['pid']['filename']):
+            f = open(yamlconfig['pid']['filename'], 'r')
             pid = f.read()
             f.close()
-            os.remove('pid')
+            os.remove(yamlconfig['pid']['filename'])
             print "Sending signal to pid: {}".format(pid)
             os.kill(int(pid), 2)
             os._exit(0)


### PR DESCRIPTION
Allow to configure the name and path of the PID file.
Please see 'pystemon.yaml' as well.