### PR TITLE
Change the way optional modules are imported

### DIFF
--- a/pystemon.py
+++ b/pystemon.py
@@ -45,6 +45,10 @@ try:
     import yaml
 except:
     exit('ERROR: Cannot import the yaml Python library. Are you sure it is installed?')
+try:
+    import redis
+except:
+    pass
 
 try:
     if sys.version_info < (2, 7):
@@ -924,8 +928,8 @@ def parse_config_file(configfile):
         except:
             exit('ERROR: Cannot import PyMongo. Are you sure it is installed ?')
     if yamlconfig['redis']['queue']:
-        try:
-            import redis
+        try: # Check if redis is defined. If not, the module is not loaded
+            redis
         except:
             exit('ERROR: Cannot import the redis Python library. Are you sure it is installed?')
 

--- a/pystemon.py
+++ b/pystemon.py
@@ -45,8 +45,13 @@ try:
     import yaml
 except:
     exit('ERROR: Cannot import the yaml Python library. Are you sure it is installed?')
+# If these optional modules are needed we will check later if they were imported
 try:
     import redis
+except:
+    pass
+try:
+    import sqlite3
 except:
     pass
 
@@ -536,9 +541,8 @@ def main():
     # start a thread to handle the DB data
     db = None
     if yamlconfig['db'] and yamlconfig['db']['sqlite3'] and yamlconfig['db']['sqlite3']['enable']:
-        try:
-            global sqlite3
-            import sqlite3
+        try: # Check if sqlite3 is defined. If not, the module is not loaded
+            sqlite3
         except:
             exit('ERROR: Cannot import the sqlite3 Python library. Are you sure it is compiled in python?')
         db = Sqlite3Database(yamlconfig['db']['sqlite3']['file'])


### PR DESCRIPTION
The first commit corrects a scoping bug when importing `redis` which made the program crash when configured to use Redis and save pastes.

The second commit imports `sqlite3` in the same way as `redis` without the need for the illegal `global sqlite3` statement.