### PR TITLE
Save metadata to mongodb

### DIFF
--- a/pystemon.yaml
+++ b/pystemon.yaml
@@ -23,6 +23,12 @@ mongo:
   url: "mongodb://localhost"
   user:
   password:
+  save_on_miss: yes     # always save meta-data (hash), even on miss match
+  meta:                 # extra meta-data
+    save: yes           # enable adding extra meta-data when saving (on hit or miss)
+    timestamp: yes      # add a timestamp (UTC)
+    url: yes            # add the public URL
+    site: yes           # add the site
 
 redis:
   queue: no


### PR DESCRIPTION
For statistic purposes I need to save in my mongodb all the pastie's metadata even if the there is no match on this pastie.

This pull request allows to chose the metadata to save:
* timestamp
* url
* site

And to save or not when there is no match.

For backward compatibility, if not specified, the previous behavior is the default one.