### PR TITLE
Force full_path to None when save-all set to no, in YAML config. file

### DIFF
--- a/pystemon.py
+++ b/pystemon.py
@@ -1122,6 +1122,7 @@ class FileStorage(PastieStorage):
             directories.append(self.save_dir)
         for directory in directories:
             if directory is None:
+		full_path = None
                 continue
             directory = directory + os.sep + pastie.site.name
             full_path = self.format_directory(directory) + os.sep + pastie.filename

--- a/pystemon.py
+++ b/pystemon.py
@@ -1117,12 +1117,12 @@ class FileStorage(PastieStorage):
     def __save_pastie__(self, pastie):
         directories = []
         res = []
+	full_path = None
         directories.append(self.archive_dir)
         if pastie.matched:
             directories.append(self.save_dir)
         for directory in directories:
             if directory is None:
-		full_path = None
                 continue
             directory = directory + os.sep + pastie.site.name
             full_path = self.format_directory(directory) + os.sep + pastie.filename

--- a/pystemon.py
+++ b/pystemon.py
@@ -1117,7 +1117,7 @@ class FileStorage(PastieStorage):
     def __save_pastie__(self, pastie):
         directories = []
         res = []
-	full_path = None
+        full_path = None
         directories.append(self.archive_dir)
         if pastie.matched:
             directories.append(self.save_dir)


### PR DESCRIPTION
Small patch to force full_path variable when you don't want to save all pasties (save-all: no in pystemon.yml).
Without this, pasties can't be saved and the log shoutout:
[2018-08-21 15:09:50,443] FileStorage: unable to save pastie[PkyUQjIE]: local variable 'full_path' referenced before assignment
[2018-08-21 15:09:50,445] Unable to save pastie PkyUQjIE: local variable 'full_path' referenced before assignment
[2018-08-21 15:09:50,456] FileStorage: unable to save pastie[54126]: local variable 'full_path' referenced before assignment
[2018-08-21 15:09:50,457] Unable to save pastie 54126: local variable 'full_path' referenced before assignment
[2018-08-21 15:09:50,464] FileStorage: unable to save pastie[4gNJZ1ck]: local variable 'full_path' referenced before assignment
[2018-08-21 15:09:50,465] Unable to save pastie 4gNJZ1ck: local variable 'full_path' referenced before assignment
[...]