### PR TITLE
Define logging level in configuration #99

### DIFF
--- a/pystemon.py
+++ b/pystemon.py
@@ -1385,7 +1385,7 @@ class Sqlite3Storage(PastieStorage):
             raise
         logger.debug('Updated pastie {site} {id} in the SQLite database.'.format(site=pastie.site.name, id=pastie.id))
 
-def parse_config_file(configfile):
+def parse_config_file(configfile, debug):
     global yamlconfig
     try:
         yamlconfig = yaml.load(open(configfile))
@@ -1395,6 +1395,11 @@ def parse_config_file(configfile):
             mark = exc.problem_mark
             logger.error("error position: (%s:%s)" % (mark.line + 1, mark.column + 1))
             exit(1)
+    if not debug and 'logging-level' in yamlconfig:
+        if  yamlconfig['logging-level'] in ['NOTSET', 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'] :
+            logger.setLevel(logging.getLevelName(yamlconfig['logging-level']))
+        else:
+            logger.error("logging level \"%s\" is invalide" % (yamlconfig['logging-level']))
     # TODO verify validity of all config parameters
     for includes in yamlconfig.get("includes", []):
         yamlconfig.update(yaml.load(open(includes)))
@@ -1588,7 +1593,7 @@ if __name__ == "__main__":
         hdlr.setFormatter(formatter)
         logger.addHandler(hdlr)
 
-    storage_engines = parse_config_file(options.config)
+    storage_engines = parse_config_file(options.config, options.debug)
     # run the software
     if options.kill:
         if os.path.isfile('pid'):

--- a/pystemon.py
+++ b/pystemon.py
@@ -1399,7 +1399,7 @@ def parse_config_file(configfile, debug):
         if  yamlconfig['logging-level'] in ['NOTSET', 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'] :
             logger.setLevel(logging.getLevelName(yamlconfig['logging-level']))
         else:
-            logger.error("logging level \"%s\" is invalide" % (yamlconfig['logging-level']))
+            logger.error("logging level \"%s\" is invalid" % (yamlconfig['logging-level']))
     # TODO verify validity of all config parameters
     for includes in yamlconfig.get("includes", []):
         yamlconfig.update(yaml.load(open(includes)))

--- a/pystemon.yaml
+++ b/pystemon.yaml
@@ -13,6 +13,8 @@ strict_regex: no        # when compiling regex, hard fail or not on error
 
 save-thread: no         # Use a separate thread to save pasties
 
+logging-level: INFO     # Define logging level (NOTSET, DEBUG, INFO, WARNING, ERROR, CRITICAL)
+
 db:
   sqlite3:              # Store information about the pastie in a database
     enable: no          # Activate this DB engine   # NOT FULLY IMPLEMENTED


### PR DESCRIPTION
The parameter `logging-level` in configuration allows you to choose the logging level of the application, `INFO` is still the default and the `--debug` overwrites it.