### PR TITLE
New throttling option closes #16

### DIFF
--- a/pystemon.yaml
+++ b/pystemon.yaml
@@ -111,6 +111,7 @@ site:
 #                       # is used for display in logging and e-mail notifications
 #    update-max: 40     # every X seconds check for new updates to see if new pasties are available
 #    update-min: 30     # a random number will be chosen between these two numbers
+#    throttling: 0      # Number of MILLIseconds to wait between downloads
 #    pastie-classname:  # OPTIONAL: The name of a custom Class that inherits from Pastie
 #                       # This is practical for sites that require custom fetchPastie() functions
 
@@ -133,15 +134,18 @@ site:
     metadata-url: 'https://scrape.pastebin.com/api_scrape_item_meta.php?i={id}'
     update-max: 50
     update-min: 40
+    throttling: 1000
 
   slexy.org:
     # note: they don't like scraping. Tuning of update-max and update-min is needed!
     # You will likely also want to enable random user-agent and proxies(see below).
+    # See https://slexy.org/tos for more information
     enable: no
     archive-url: 'https://slexy.org/recent'
     archive-regex: '<a href="/view/([a-zA-Z0-9]+)">View paste</a>'
     download-url: 'https://slexy.org/view/{id}'
     pastie-classname: PastieSlexyOrg
+    throttling: 1000
 
   gist.github.com:
     enable: yes


### PR DESCRIPTION
Hi there,
as there are more and more sites enforcing rate limiting, we added a new option, "throttling", which allows a pause of n milliseconds between each call to download_url. This relies on a new thread created for each site that requires throttling.
The synchronisation mechanism is based on a tupple passed to download_url (which, incidentally, accepts now a new parameter). This tupple contains a (throttler.thread, threading.Lock). When download_url needs to fetch something, it wakes up the throttler, acquires the Lock, and wait for the throttler to release the Lock. Then it downloads whatever is needed. meanwhile, the throttler sleeps for the number of milliseconds configured, then block again, waiting for another download_url to wake it up.