### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ PyYAML
 BeautifulSoup4
 lxml
 requests
+redis


### PR DESCRIPTION
Solves this error, after pip installing the requirements

`(env-pystemon) root@debian:/opt/pystemon/pystemon# python pystemon.py
pystemon.yaml
[2021-03-11 16:07:09,636] Pystemon[7261]: Starting up ...
[2021-03-11 16:07:09,641] [redis]: unable to load storage module: No module named redis
Traceback (most recent call last):
  File "pystemon.py", line 355, in <module>
    main(config)
  File "pystemon.py", line 218, in main
    new_threads = load_config(config)
  File "pystemon.py", line 59, in load_config
    config.reload()
  File "/opt/pystemon/pystemon/pystemon/config.py", line 224, in reload
    raise PystemonConfigException('Unable to parse configuration: {}'.format(e))
pystemon.exception.PystemonConfigException: Unable to parse configuration: No module named redis `