### PR TITLE
Fix thread crash when pastie content size is 0

### DIFF
--- a/pystemon/pastie/__init__.py
+++ b/pystemon/pastie/__init__.py
@@ -113,6 +113,12 @@ class Pastie():
             else:
                 delta = self.fetch_end_time - self.fetch_start_time
                 logger.debug('fetched pastie {id}: {s}s, {b}B'.format(id=self.id, s=delta, b=len(content)))
+                if len(content) == 0: #Handle error where content is edited to 0 the thread will fail
+                    self.pastie_content = None
+                    logger.error('ERROR: Pastie size is 0B, ignoring {site} {id}'.format(
+                        site=self.site.name,
+                        id=self.id))
+
         except Exception as e:
             logger.error('ERROR: Failed to fetch pastie {site} {id}: {e}'.format(
                 site=self.site.name,

--- a/pystemon/pastie/__init__.py
+++ b/pystemon/pastie/__init__.py
@@ -110,14 +110,14 @@ class Pastie():
             delta = self.fetch_end_time = time.time()
             if content is None:
                 logger.debug('failed to fetch pastie {id}'.format(id=self.id))
+            elif len(content) == 0:
+                self.pastie_content = None
+                logger.error('ERROR: Pastie size is 0B, ignoring {site} {id}'.format(
+                    site=self.site.name,
+                    id=self.id))
             else:
                 delta = self.fetch_end_time - self.fetch_start_time
                 logger.debug('fetched pastie {id}: {s}s, {b}B'.format(id=self.id, s=delta, b=len(content)))
-                if len(content) == 0: #Handle error where content is edited to 0 the thread will fail
-                    self.pastie_content = None
-                    logger.error('ERROR: Pastie size is 0B, ignoring {site} {id}'.format(
-                        site=self.site.name,
-                        id=self.id))
 
         except Exception as e:
             logger.error('ERROR: Failed to fetch pastie {site} {id}: {e}'.format(


### PR DESCRIPTION
Hello,

I have detected an issue happening frequently, essentially with ideone but also noticed with gist.github.com.
After getting the recent items, pystemon start downloading them one by one. If between the /recent request and the effective download of the pastie the content is edited by the user to empty (not deleting juste remove all the code within) the download thread for the site will crash. Then pystemon will stop downloading pasties for the site.

The queue will continue to grow up but all the pasties will never be downloaded.

I have added a simple check, if the size is 0, then print a debug message and set the content to None in order go to the correct state in fetch_and_process_pastie.

For reproduce the bug :
- Create a code sample on ideone
- Wait a few minutes for letting new code samples being created by others users
- Launch pystemon and let him retrieve the /recent list
- When the list is collected, edit the code sample before the downloading occurs (remove all content but do not delete the pastie)

Hope this is the right way to do the PR (first time huh :))

Cheers