### PR TITLE
Add proxy use per site

### DIFF
--- a/pystemon.py
+++ b/pystemon.py
@@ -103,7 +103,7 @@ def load_config(config):
 
             for i in range(config.threads):
                 name = "[ThreadPasties][{}][{}]".format(site.name, i+1)
-                user_agent = PystemonUA(name, config.proxies_list,
+                user_agent = PystemonUA(name, config.proxies_list, proxify_all=config.proxify_all,
                         user_agents_list = config.user_agents_list,
                         throttler=throttler, ip_addr=config.ip_addr)
                 t = ThreadPasties(user_agent, queue_name=site.name, queue=site.queue)
@@ -112,7 +112,7 @@ def load_config(config):
 
             # Compressed is used to guess the filename, so it's mandatory to pass it along
             name = "[PastieSite][{}]".format(site.name)
-            site_ua=PystemonUA(name, config.proxies_list,
+            site_ua=PystemonUA(name, config.proxies_list, proxify_all=config.proxify_all,
                 user_agents_list = config.user_agents_list,
                 throttler = throttler, ip_addr = config.ip_addr)
             t = PastieSite(site.name, site.download_url, site.archive_url, site.archive_regex,
@@ -121,6 +121,7 @@ def load_config(config):
                     site_update_min = site.update_min,
                     site_update_max = site.update_max,
                     site_pastie_classname = site.pastie_classname,
+                    site_use_proxy = site.use_proxy,
                     site_save_dir = config.save_dir,
                     site_archive_dir = config.archive_dir,
                     archive_compress = config.compress,

--- a/pystemon/pastie/__init__.py
+++ b/pystemon/pastie/__init__.py
@@ -73,6 +73,7 @@ class Pastie():
         self.md5 = None
         self.url = self.site.download_url.format(id=self.id)
         self.public_url = self.site.public_url.format(id=self.id)
+        self.use_proxy = self.site.use_proxy
         self.metadata_url = None
         if self.site.metadata_url is not None:
             self.metadata_url = self.site.metadata_url.format(id=self.id)
@@ -92,11 +93,11 @@ class Pastie():
 
     def fetch_pastie(self):
         if self.metadata_url is not None:
-            response = self.download_url(self.metadata_url)
+            response = self.download_url(self.metadata_url, use_proxy=self.use_proxy)
             if response is not None:
                 response = response.content
                 self.pastie_metadata = response
-        response = self.download_url(self.url)
+        response = self.download_url(self.url, use_proxy=self.use_proxy)
         if response is not None:
             response = response.content
             self.pastie_content = response

--- a/pystemon/pastiesite.py
+++ b/pystemon/pastiesite.py
@@ -56,6 +56,7 @@ class PastieSite(threading.Thread):
         if kwargs['site_metadata_url'] is not None:
             self.metadata_url = kwargs['site_metadata_url']
 
+        self.use_proxy = kwargs.get('site_use_proxy', False)
         self.archive_compress = kwargs.get('archive_compress', False)
         self.update_min = kwargs['site_update_min']
         self.update_max = kwargs['site_update_max']
@@ -164,7 +165,7 @@ class PastieSite(threading.Thread):
         # reset the pasties list
         pasties = []
         # populate queue with data
-        response = self.user_agent.download_url(self.archive_url)
+        response = self.user_agent.download_url(self.archive_url, use_proxy=self.use_proxy)
         if not response:
             logger.warning("Failed to download page {url}".format(url=self.archive_url))
             return False


### PR DESCRIPTION
Hello,

For some needs I've implemented some changes on pystemon in order to be able to use a proxy only for some site.
It is now possible to add _use-proxy_ directive to site in order to use random proxy only on the select site

Now the ProxyList is setted if `proxy.random: yes` or if one enabled site have` use-proxy: yes` in his configuration.
Example :
```
  pastebin.gr:
    enable: no
    archive-url: 'http://pastebin.gr/archive'
    archive-regex: '<td><a href="(\d+)" title='
    download-url: 'http://pastebin.gr/paste.php?download&id={id}'
    throttling: 5000
    use-proxy: yes
```
If `proxy.random: yes` proxy will still be used for all sites
I have also disabled sslVerify in order to be able to proxify https request to http servers and added 'https' for proxy in session.

The code is maybe not clean at all or far away from your guidelines. Do not hesitate to tell me if something is bad :)

Cheers !