### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pystemon.py
+++ b/pystemon.py
@@ -86,7 +86,7 @@ def load_config(config):
     '''
      for each site enabled:
      - get the configuration
-     - if successfull, create a queue
+     - if successful, create a queue
      - create a thread to refresh the list of pasties to download (consumer)
      - create a thread to download the pasties (consumer)
      - if needed, create a thread to throttle all the other threads (producer)

--- a/pystemon/storage/sqlite3storage.py
+++ b/pystemon/storage/sqlite3storage.py
@@ -17,7 +17,7 @@ class Sqlite3Storage(PastieStorage):
         except KeyError:
             logger.debug('Re-opening Sqlite database {0} in thread[{1}]'.format(self.filename, thread_id))
             # autocommit and write ahead logging
-            # works well because we have only 1 writter for n readers
+            # works well because we have only 1 writer for n readers
             db_conn = sqlite3.connect(self.filename, isolation_level=None)
             db_conn.execute('pragma journal_mode=wal')
             cursor = db_conn.cursor()


### PR DESCRIPTION
There are small typos in:
- pystemon.py
- pystemon/storage/sqlite3storage.py

Fixes:
- Should read `writer` rather than `writter`.
- Should read `successful` rather than `successfull`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md