### PR TITLE
Implementing support for multiple Telegram chat_ids

### DIFF
--- a/pystemon.yaml
+++ b/pystemon.yaml
@@ -58,8 +58,10 @@ storage:
   telegram:
     storage-classname:    TelegramStorage
     enable: no            # Enable this alerting engine
+    save: yes
     token: 0              # see https://core.telegram.org/bots/api#authorizing-your-bot
-    chat-id: 0
+    chat-ids:
+      - 0
 
 email:
   alert: no             # Enable/disable email alerts
@@ -178,7 +180,7 @@ site:
     download-url: 'http://paste.org.ru/?{id}'
     pastie-classname: PastiePasteOrgRu
     throttling: 5000
- 
+
   kpaste.net:
     enable: no
     archive-url: 'http://kpaste.net/'
@@ -206,7 +208,7 @@ site:
     archive-regex: '<td><a href="(\d+)" title='
     download-url: 'http://pastebin.gr/paste.php?download&id={id}'
     throttling: 5000
-    
+
   pastebin.pl:
     enable: no
     archive-url: 'https://pastebin.pl/lists'

--- a/pystemon/storage/telegramstorage.py
+++ b/pystemon/storage/telegramstorage.py
@@ -1,6 +1,7 @@
 
 import logging.handlers
 import requests
+from pystemon.storage import PastieStorage
 
 logger = logging.getLogger('pystemon')
 
@@ -8,7 +9,7 @@ class TelegramStorage(PastieStorage):
 
     def __init_storage__(self, **kwargs):
         self.token = kwargs.get('token')
-        self.chat_id = kwargs.get('chat-id')
+        self.chat_ids = kwargs.get('chat-ids')
 
     def __save_pastie__(self, pastie):
         if pastie.matched:
@@ -26,10 +27,9 @@ Below (after newline) is the content of the pastie:
         '''.format(site=pastie.site.name, url=pastie.public_url, matches=pastie.matches_to_regex(), content=pastie.pastie_content.decode('utf8'))
 
             url = 'https://api.telegram.org/bot{0}/sendMessage'.format(self.token)
-            try:
-                logger.debug('Sending message to telegram {} for pastie_id {}'.format(url, pastie.id))
-                requests.post(url, data={'chat_id': self.chat_id, 'text': message})
-            except Exception as e:
-                logger.warning("Failed to alert through telegram: {0}".format(e))
-
-
+            for chat_id in self.chat_ids:
+                try:
+                    logger.debug('Sending message to telegram {} for pastie_id {}'.format(url, pastie.id))
+                    requests.post(url, data={'chat_id': chat_id, 'text': message})
+                except Exception as e:
+                    logger.warning("Failed to alert through telegram: {0}".format(e))


### PR DESCRIPTION
This PR implements the changes suggested in #123 
It fixes the PastieStorage import to ensure the Telegram storage works deterministically and implements a loop through the chat ids.
The configuration file has been modified to reflect the changes, renaming chat_id to chat_ids, changing the example to a list format, and setting the save option to hint that it's needed.